### PR TITLE
Change docker restart policy

### DIFF
--- a/bash/provision-master.sh
+++ b/bash/provision-master.sh
@@ -30,7 +30,7 @@ mv ke /usr/local/bin/ke
 rm ke.tar.gz
 
 ## start load balance
-docker container run --rm \
+docker container run --restart unless-stopped \
   --detach \
   -v /home/vagrant/erase-una-vez-k8s/lb/envoy.yaml:/etc/envoy/envoy.yaml \
   -p 80:80 \


### PR DESCRIPTION
… envoyproxy docker is restarted after the VMs are shutdown instead of removed.

Cuando miras el capítulo de "Ingress", o haces una instalación limpia de K8S o los ejemplos del capítulo no funcionarán si se han parado las máquinas virtuales ya que con docker run --rm al terminarse el docker, éste se destruye. Por eso considero mejor reiniciar el docker del envoyproxy cuando se reinicia la máquina virtual máster en lugar de destruirlo.