### PR TITLE
Use docker network in envoy cluster configuration

### DIFF
--- a/lb/envoy.yaml
+++ b/lb/envoy.yaml
@@ -25,26 +25,15 @@ static_resources:
                   route: { cluster: http }
             http_filters:
             - name: envoy.router
-    - name: listener_0
+    - name: listener_1
       address:
         socket_address: { address: 0.0.0.0, port_value: 443 }
       filter_chains:
       - filters:
-        - name: envoy.http_connection_manager
-          typed_config:
-            "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
-            stat_prefix: ingress_http
-            codec_type: AUTO
-            route_config:
-              name: local_route
-              virtual_hosts:
-              - name: local_service
-                domains: ["*"]
-                routes:
-                - match: { prefix: "/" }
-                  route: { cluster: https }
-            http_filters:
-            - name: envoy.router
+        - name: envoy.tcp_proxy
+          config:
+            stat_prefix: ingress_tcp
+            cluster: https
 
   clusters:
     - name: http
@@ -53,7 +42,7 @@ static_resources:
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN
       hosts: [
-        { socket_address: { address: 192.168.100.10, port_value: 30080 }}
+        { socket_address: { address: 172.17.0.1, port_value: 30080 }}
       ]
     - name: https
       connect_timeout: 0.25s
@@ -61,5 +50,5 @@ static_resources:
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN
       hosts: [
-        { socket_address: { address: 192.168.100.10, port_value: 30443 }}
+        { socket_address: { address: 172.17.0.1, port_value: 30443 }}
       ]


### PR DESCRIPTION
…er_0 which kept https from working and ii) As tls is usually defined in the ingress definition, Envoy shouldn't do anything with https since it has no knownled about certificates in this case, so, it is seems to be better to passthrough https as a tcp proxy

I've also changed the 192.168.100.10 IP which depends on your vagrant configuration for the docker0 interface. As Envoy is run inside a docker, the gateway for the docker will very likely be 172.17.0.1 unless this is changed in the docker configuration which is rarelly done.